### PR TITLE
add missing "empty" option for rarity

### DIFF
--- a/src/Form/ItemFormType.php
+++ b/src/Form/ItemFormType.php
@@ -43,6 +43,7 @@ class ItemFormType extends AbstractType
                 'choice_label' => 'name',
                 'choices' => $options['rarityChoices'],
                 'label' => 'label.rarity',
+                'placeholder' => 'label.parent_placeholder',
                 'required' => true
             ])
             ->add('submit', SubmitType::class, [

--- a/src/Form/TableFormType.php
+++ b/src/Form/TableFormType.php
@@ -37,6 +37,7 @@ class TableFormType extends AbstractType
                 'choice_label' => 'name',
                 'choices' => $options['rarityChoices'],
                 'label' => 'label.rarity',
+                'placeholder' => 'label.parent_placeholder',
                 'required' => true
             ])
             ->add('submit', SubmitType::class,[


### PR DESCRIPTION
This results in forms getting validated properly again.
Closes #44 